### PR TITLE
Feat/careguide download plants

### DIFF
--- a/src/Home/PersonalHome.js
+++ b/src/Home/PersonalHome.js
@@ -5,11 +5,12 @@ import {
   ScrollView,
   RefreshControl,
   Linking,
+  ActivityIndicator,
 } from 'react-native';
 import PropTypes from 'prop-types';
 
 import {
-  Touchable, Type, DetailHeader, Media, Button, ScreenWithBottomNav,
+  Touchable, Type, DetailHeader, Media, Button, ScreenWithBottomNav
 } from '../shared/components';
 import {
   space, COLORS, hitSlop, LINKS,
@@ -131,9 +132,9 @@ const PersonalHome = ({ navigation }) => {
             <View style={styles.sidePadding}>
               <DetailHeader weight="bold">What&apos;s it like outside?</DetailHeader>
             </View>
-            {zipcode || loadingZipcode ? (
+            {zipcode || loadingZipcode || !auth ? (
               <View style={{ paddingVertical: space[2] }}>
-                <Weather zipcode={zipcode} loadingZipcode={loadingZipcode} />
+                <Weather zipcode={zipcode} loadingZipcode={loadingZipcode || !auth.user} />
               </View>
             ) : (
               <View style={styles.infoBox}>
@@ -159,13 +160,16 @@ const PersonalHome = ({ navigation }) => {
                 </Touchable>
               </Media.Item>
             </Media>
-            <MySavedPlants
-              onAddPlant={handleAddPlantPress}
-              reloadToggle={reloadPlantsToggle}
-              navigate={navigation.navigate}
-              signout={auth.signout}
-              style={{ paddingLeft: space[2] }}
-            />
+            {auth && auth.user ? (
+              <MySavedPlants
+                onAddPlant={handleAddPlantPress}
+                reloadToggle={reloadPlantsToggle}
+                navigate={navigation.navigate}
+                signout={auth.signout}
+                user={auth.user}
+                style={{ paddingLeft: space[2] }}
+              />
+            ) : <ActivityIndicator />}
           </View>
           <View style={styles.feedbackSection}>
             <DetailHeader weight="bold">How can we do better?</DetailHeader>

--- a/src/Home/components/MySavedPlants.js
+++ b/src/Home/components/MySavedPlants.js
@@ -11,7 +11,7 @@ import {
   Touchable, PageLoader, ErrorState, Type, Button, PlantBlock
 } from '../../shared/components';
 import { space, centered } from '../../shared/constants';
-import { loadStoredPlants } from '../data';
+import { getUserPlants } from '../data';
 
 const styles = StyleSheet.create({
   container: {
@@ -43,6 +43,7 @@ const MySavedPlants = ({
   signout,
   reloadToggle,
   onAddPlant,
+  user,
   ...passedProps,
 }) => {
   const [loading, setLoading] = useState(false);
@@ -52,8 +53,9 @@ const MySavedPlants = ({
   // TODO: check against db for updates
 
   useEffect(() => {
+    const { uid } = user;
     setLoading(true);
-    loadStoredPlants()
+    getUserPlants(uid)
       .then((downloadedPlants) => {
         setPlants(downloadedPlants);
         setLoading(false);
@@ -64,13 +66,15 @@ const MySavedPlants = ({
         setError(true);
       });
     return () => { setError(false); setErrorCount(0); setLoading(false); };
-  }, [reloadToggle]);
+  }, [reloadToggle, user]);
 
   const loadPlants = async () => {
+    const { uid } = user;
+    if (!user) return;
     setLoading(true);
     setError(false);
     try {
-      const downloadedPlants = await loadStoredPlants();
+      const downloadedPlants = await getUserPlants(uid);
       setPlants(downloadedPlants);
       setLoading(false);
     } catch (e) {
@@ -144,6 +148,7 @@ MySavedPlants.propTypes = {
   signout: PropTypes.func,
   reloadToggle: PropTypes.number,
   onAddPlant: PropTypes.func,
+  user: PropTypes.object,
 };
 
 export default MySavedPlants;

--- a/src/shared/data/plantStorage.js
+++ b/src/shared/data/plantStorage.js
@@ -1,0 +1,36 @@
+import * as firebase from 'firebase';
+import 'firebase/firestore';
+
+import handleError from './handleError';
+import {
+  storePlant,
+  storeSpecies,
+} from './localStorage';
+
+const fetchAndSavePlantSpecies = async (speciesId) => {
+  let speciesInfo;
+  try {
+    const result = await firebase
+      .firestore()
+      .collection('species')
+      .doc(speciesId)
+      .get();
+    speciesInfo = result.data();
+    return storeSpecies(speciesId, speciesInfo);
+  } catch (e) {
+    handleError(e);
+    throw e;
+  }
+};
+
+export const storeUserPlant = async (plant) => {
+  let storedPlant;
+  try {
+    storedPlant = await storePlant(plant.id, plant);
+  } catch (e) {
+    handleError(e);
+  }
+  return fetchAndSavePlantSpecies(plant.speciesId, storedPlant);
+};
+
+export default null;


### PR DESCRIPTION
This change fixes a bug where if a user re-downloads the Gardenio app with no local data stored, it looks like they don't have any plants even though they have them on their user in the database. This is because previously we were just checking the local storage of the phone for which plants they have. Now, if no plants are found locally it fetches from the user's myPlants database and stores the information to their phone.

This change also updates the plant delete action from a hard delete (removing from the database) to a soft delete (adding `deletedOn` to the plant and removing from local storage)